### PR TITLE
Adds source ~/.rvm/scripts/rvm to see if it will fix this error:

### DIFF
--- a/roles/common/files/rvm_install.sh
+++ b/roles/common/files/rvm_install.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 curl -L https://get.rvm.io | bash -s stable --ruby=$1
+source ~/.rvm/scripts/rvm


### PR DESCRIPTION
TASK [common : Install ruby and rvm] *******************************************
fatal: [127.0.0.1]: FAILED! => {"changed": true, "failed": true, "rc": 2, "stderr": "/bin/sh: 1: cannot create /var/log/rvm_install.log: Permission denied\n", "stdout": "", "stdout_lines": []}
